### PR TITLE
When converting data to json, "Object of type int64 is not JSON serializable" error occurs

### DIFF
--- a/floweaver/sankey_data.py
+++ b/floweaver/sankey_data.py
@@ -7,6 +7,7 @@ Created: 2018-01-15
 import json
 import attr
 from collections import defaultdict
+from numpyencoder import NumpyEncoder
 
 from .sankey_definition import _validate_direction, _convert_ordering
 from .ordering import Ordering
@@ -55,7 +56,7 @@ class SankeyData(object):
             return data
         else:
             with open(filename, "wt") as f:
-                json.dump(data, f)
+                json.dump(data, f, cls=NumpyEncoder)
 
     def to_widget(
         self,


### PR DESCRIPTION
I tried to convert my sankey data to json, using the .to_json function. However, the following error is returned:

_Object of type int64 is not JSON serializable_

When looking at the code, the code is converted using:

`json.dump(data, f)`

The data object contains a pandas dataframe, and this is in effect a numpy array, which seems to be where the problem originates. See [here](https://stackoverflow.com/questions/26646362/numpy-array-is-not-json-serializable) and [here](https://stackoverflow.com/questions/50916422/python-typeerror-object-of-type-int64-is-not-json-serializable/61903895) for instance.

This pull request should resolve this issue.